### PR TITLE
Update unicocheck-ios to v3.0.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -5,7 +5,7 @@ target 'sample-app-new' do
   # Comment the next line if you don't want to use dynamic frameworks
   use_frameworks!
 
-  pod 'unicocheck-ios', '2.22.0'
+  pod 'unicocheck-ios', '3.0.0'
 
   target 'sample-app-newTests' do
     inherit! :search_paths


### PR DESCRIPTION
Automatic update of `unicocheck-ios` to version **3.0.0**

    **Release date:** 14/05/2026
    🔗 Official Release Notes: https://devcenter.unico.io/unico-idcloud/by-client-integration/pt/sdk/sdks-disponiveis/sdk-ios/release-notes

    **Changelog:**
    - Versão mínima do iOS: O suporte ao iOS 12 foi encerrado. A versão mínima suportada passa a ser o iOS 13.
- Captura híbrida mais fluida: eliminação de prompts desnecessários de geolocalização durante o fluxo de captura biométrica.
- Melhorias internas de produto. Essas melhorias não afetam diretamente a experiência do usuário final, mantendo a interface e funcionalidades externas inalteradas.